### PR TITLE
Fix "stps.source(...).pipe is not a function" error

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ function webSocketPullStream (socket, binary) {
 
     s.emit = function (type, stream) {
       if (type !== 'pipe') {return;}
-      stps.source(stream).pipe(s)
+      pull(stps.source(stream), s)
     }
     s.Tunnel = Tunnel;
     return s;


### PR DESCRIPTION
It fixes the following exception thrown when running "examples/quick":

```
TypeError: stps.source(...).pipe is not a function
    at Function.s.emit (websocket-pull-stream/index.js:71:27)
    at ReadStream.Readable.pipe (_stream_readable.js:604:8)
```